### PR TITLE
Fixes incorrect spacing near nbsp

### DIFF
--- a/fr-nbsp.lua
+++ b/fr-nbsp.lua
@@ -27,7 +27,7 @@ local function insert_nonbreaking_space_before_last_char(text)
     return text:sub(1, -2) .. space .. text:sub( -1)
 end
 
-local function string_already_has_nbsp(text)
+local function string_already_has_nbsp(text) -- OR PRECEDED BY '\'
     --[[ aarc: I think this overgeneralises:
     return string.find(text, THIN_NBSP)
         or string.find(text, NBSP)

--- a/fr-nbsp.lua
+++ b/fr-nbsp.lua
@@ -27,7 +27,7 @@ local function insert_nonbreaking_space_before_last_char(text)
     return text:sub(1, -2) .. space .. text:sub( -1)
 end
 
-local function string_already_has_nbsp(text) -- OR PRECEDED BY '\'
+local function string_already_has_nbsp(text) -- OR IS PRECEDED BY '\'
     --[[ aarc: I think this overgeneralises:
     return string.find(text, THIN_NBSP)
         or string.find(text, NBSP)
@@ -54,6 +54,8 @@ local function space_high_punctuation_and_quotes(inlines)
             inlines[i].text = string.gsub(inlines[i].text, "€", NBSP .. "€")
             inlines[i].text = string.gsub(inlines[i].text, "»", NBSP .. "»")
             inlines[i].text = string.gsub(inlines[i].text, "«", "«" .. NBSP)
+            inlines[i].text = string.gsub(inlines[i].text, "›", NBSP .. "›")
+            inlines[i].text = string.gsub(inlines[i].text, "‹", "‹" .. NBSP)
         end
 
         --

--- a/fr-nbsp.lua
+++ b/fr-nbsp.lua
@@ -28,8 +28,9 @@ local function insert_nonbreaking_space_before_last_char(text)
 end
 
 local function string_already_has_nbsp(text)
-    return string.find(text, THIN_NBSP)
-        or string.find(text, NBSP)
+    -- check no nbsp in last 3 characters (so that ?! works)
+    return string.find(text:sub(-3), THIN_NBSP)
+        or string.find(text:sub(-3), NBSP)
 end
 
 --- add non-breaking spaces according to high punctuation rules, similar to babel-french


### PR DESCRIPTION
Resolves #3 by only looking back two characters when checking a string for no-break spaces (strictly: looks at last three characters).

This has the advantage of producing the desired behaviour for `text?! --> text&nbsp;?!`, but breaks for longer sets, e.g. `!!!!!!!!!!!!` (haven't actually tested this). 

I suspect there might be a better way to do this, e.g. checking 

```lua
local function string_already_has_nbsp(text)
    return string.find(text:sub(-3), THIN_NBSP)
        or string.find(text:sub(-3), NBSP)
        or string.find(text:sub(#text-1, #text-1), ALL_SPACE_PATTERN_ASCII) -- checks if last character is special
end
```

but I'm not sure that doesn't break something else.